### PR TITLE
definitions.mk: look for definitions.mk in device/*/build also

### DIFF
--- a/core/definitions.mk
+++ b/core/definitions.mk
@@ -2237,6 +2237,7 @@ include $(BUILD_SYSTEM)/distdir.mk
 
 # Include any vendor specific definitions.mk file
 -include $(TOPDIR)vendor/*/build/core/definitions.mk
+-include $(TOPDIR)device/*/build/core/definitions.mk
 
 # broken:
 #	$(foreach file,$^,$(if $(findstring,.a,$(suffix $file)),-l$(file),$(file)))


### PR DESCRIPTION
build/core/Makefile looks for build tasks in either device/*/build/tasks
or vendor/*/build/tasks. Do the same with vendor-specific definitions.mk.

Upstream review URL:
https://android-review.googlesource.com/#/c/112252/

Change-Id: Ib4fd00a1d0effe8e347382a922da101ce26bf696
Signed-off-by: Andrew Boie <andrew.p.boie@intel.com>
Reviewed-on: https://android.intel.com/294088