### PR TITLE
Use Qualcomm Snapdragon LLVM Compiler 3.6

### DIFF
--- a/core/binary.mk
+++ b/core/binary.mk
@@ -97,6 +97,17 @@ else
   endif
 endif
 
+ifeq ($(USE_CLANG_QCOM),true)
+  ifndef LOCAL_IS_HOST_MODULE
+    ifeq ($(LOCAL_MODULE),$(filter $(LOCAL_MODULE),$(CLANG_QCOM_FORCE_COMPILE_MODULES)))
+      LOCAL_CLANG := true
+    endif
+    #ifneq ($(LOCAL_CLANG),true)
+    #  $(info gcc target module: $(LOCAL_MODULE))
+    #endif
+  endif
+endif
+
 # The following LOCAL_ variables will be modified in this file.
 # Because the same LOCAL_ variables may be used to define modules for both 1st arch and 2nd arch,
 # we can't modify them in place.
@@ -242,10 +253,14 @@ my_target_global_cppflags :=
 endif # LOCAL_SDK_VERSION
 
 ifeq ($(my_clang),true)
-my_target_global_cflags := $($(LOCAL_2ND_ARCH_VAR_PREFIX)CLANG_TARGET_GLOBAL_CFLAGS)
-my_target_global_cppflags += $($(LOCAL_2ND_ARCH_VAR_PREFIX)CLANG_TARGET_GLOBAL_CPPFLAGS)
-my_target_global_ldflags := $($(LOCAL_2ND_ARCH_VAR_PREFIX)CLANG_TARGET_GLOBAL_LDFLAGS)
-my_target_c_includes += $(CLANG_CONFIG_EXTRA_TARGET_C_INCLUDES)
+  ifeq ($(USE_CLANG_QCOM)$(filter $(LOCAL_MODULE),$(CLANG_QCOM_DONT_USE_MODULES)),true)
+    include $(BUILD_SYSTEM)/clang/clang_qcom_global.mk
+  else
+    my_target_c_includes += $(CLANG_CONFIG_EXTRA_TARGET_C_INCLUDES)
+    my_target_global_cflags := $($(LOCAL_2ND_ARCH_VAR_PREFIX)CLANG_TARGET_GLOBAL_CFLAGS)
+    my_target_global_cppflags += $($(LOCAL_2ND_ARCH_VAR_PREFIX)CLANG_TARGET_GLOBAL_CPPFLAGS)
+    my_target_global_ldflags := $($(LOCAL_2ND_ARCH_VAR_PREFIX)CLANG_TARGET_GLOBAL_LDFLAGS)
+  endif
 else
 my_target_global_cflags := $($(LOCAL_2ND_ARCH_VAR_PREFIX)TARGET_GLOBAL_CFLAGS)
 my_target_global_cppflags += $($(LOCAL_2ND_ARCH_VAR_PREFIX)TARGET_GLOBAL_CPPFLAGS)
@@ -365,8 +380,17 @@ normal_objects_mode := $(if $(LOCAL_ARM_MODE),$(LOCAL_ARM_MODE),thumb)
 arm_objects_cflags := $($(LOCAL_2ND_ARCH_VAR_PREFIX)$(my_prefix)$(arm_objects_mode)_CFLAGS)
 normal_objects_cflags := $($(LOCAL_2ND_ARCH_VAR_PREFIX)$(my_prefix)$(normal_objects_mode)_CFLAGS)
 ifeq ($(strip $(my_clang)),true)
-arm_objects_cflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(arm_objects_cflags))
-normal_objects_cflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(normal_objects_cflags))
+    ifndef LOCAL_IS_HOST_MODULE
+      ifeq ($(USE_CLANG_QCOM)$(filter $(LOCAL_MODULE),$(CLANG_QCOM_DONT_USE_MODULES)),true)
+        include $(BUILD_SYSTEM)/clang/clang_qcom_objects.mk
+      else
+        arm_objects_cflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(arm_objects_cflags))
+        normal_objects_cflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(normal_objects_cflags))
+      endif
+    else
+      arm_objects_cflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(arm_objects_cflags))
+      normal_objects_cflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(normal_objects_cflags))
+    endif
 endif
 
 else
@@ -923,10 +947,21 @@ endif
 ###########################################################
 
 ifeq ($(my_clang),true)
-my_cflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(my_cflags))
-my_cppflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(my_cppflags))
-my_asflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(my_asflags))
-my_ldflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(my_ldflags))
+  ifndef LOCAL_IS_HOST_MODULE
+    ifeq ($(USE_CLANG_QCOM)$(filter $(LOCAL_MODULE),$(CLANG_QCOM_DONT_USE_MODULES)),true)
+        include $(BUILD_SYSTEM)/clang/clang_qcom_local.mk
+    else
+      my_cflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(my_cflags))
+      my_cppflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(my_cppflags))
+      my_asflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(my_asflags))
+      my_ldflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(my_ldflags))
+    endif
+  else
+    my_cflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(my_cflags))
+    my_cppflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(my_cppflags))
+    my_asflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(my_asflags))
+    my_ldflags := $(call $(LOCAL_2ND_ARCH_VAR_PREFIX)convert-to-$(my_host)clang-flags,$(my_ldflags))
+  endif
 endif
 
 ifeq ($(LOCAL_FDO_SUPPORT), true)

--- a/core/clang/TARGET_arm_qcom.mk
+++ b/core/clang/TARGET_arm_qcom.mk
@@ -1,0 +1,405 @@
+### Define paths
+LLVM_PREBUILTS_PATH_QCOM := prebuilts/clang/linux-x86/host/llvm-Snapdragon_LLVM_for_Android_3.6/prebuilt/linux-x86_64/bin
+LLVM_PREBUILTS_HEADER_PATH_QCOM := $(LLVM_PREBUILTS_PATH_QCOM)/../lib/clang/3.6.0/include/
+LLVM_PREBUILTS_LIBRARIES_PATH_QCOM := $(LLVM_PREBUILTS_PATH_QCOM)/../lib/clang/3.6.0/lib
+
+CLANG_QCOM_EXTRA_OPT_LIBGCC := \
+  -L $(LLVM_PREBUILTS_LIBRARIES_PATH_QCOM)/linux/ \
+  -l clang_rt.builtins-arm-android
+
+CLANG_QCOM_EXTRA_OPT_LIBGCC_LINK := \
+  $(LLVM_PREBUILTS_LIBRARIES_PATH_QCOM)/linux/libclang_rt.builtins-arm-android.a
+
+CLANG_QCOM_EXTRA_OPT_LIBRARIES_LINK := \
+  $(LLVM_PREBUILTS_LIBRARIES_PATH_QCOM)/linux-propri_rt/libclang_rt.optlibc-krait.a \
+  $(LLVM_PREBUILTS_LIBRARIES_PATH_QCOM)/linux-propri_rt/libclang_rt.translib32.a
+
+$(LOCAL_2ND_ARCH_VAR_PREFIX)TARGET_LIBGCC += $(CLANG_QCOM_EXTRA_OPT_LIBRARIES_LINK)
+
+
+
+### Define compile flags
+CLANG_QCOM_CONFIG_arm_TARGET_TRIPLE := armv7a-linux-androideabi
+
+CLANG_QCOM_CONFIG_arm_TARGET_TOOLCHAIN_PREFIX := \
+  $(TARGET_TOOLCHAIN_ROOT)/arm-linux-androideabi/bin
+
+CLANG_QCOM_CONFIG_LLVM_DEFAULT_FLAGS := \
+  -ffunction-sections \
+  -no-canonical-prefixes \
+  -fstack-protector
+  #-funwind-tables
+  #-fpic
+
+CLANG_QCOM_CONFIG_LLVM_EXTRA_FLAGS := \
+  -Qunused-arguments -Wno-unknown-warning-option -D__compiler_offsetof=__builtin_offsetof \
+  -Wno-tautological-constant-out-of-range-compare \
+  -fcolor-diagnostics \
+  -fstrict-aliasing \
+  -Wstrict-aliasing=2 \
+  -Werror=strict-aliasing \
+  -fuse-ld=gold \
+  -Wno-missing-field-initializers \
+  -Wno-unused-local-typedef \
+  -Wno-inconsistent-missing-override \
+  -Wno-null-dereference \
+  -Wno-enum-compare
+  #-Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable
+
+#http://pastebin.com/PZtk6WHB
+ifeq ($(TARGET_CPU_VARIANT),krait)
+  clang_qcom_mcpu := -mcpu=krait
+  clang_qcom_muse-optlibc := -muse-optlibc
+  clang_qcom_mcpu_as := -mcpu=cortex-a15 -mfpu=neon-vfpv4 -mfloat-abi=softfp
+else ifeq ($(TARGET_CPU_VARIANT),scorpion)
+  clang_qcom_mcpu := -mcpu=scorpion
+  clang_qcom_mcpu_as := -mcpu=cortex-a8 -mfpu=neon-vfpv3 -mfloat-abi=softfp
+  clang_qcom_muse-optlibc :=
+else
+  $(info  )
+  $(info QCOM_CLANG: warning no supported cpu detected.)
+  $(exit)
+endif
+
+CLANG_QCOM_CONFIG_KRAIT_ALIGN_FLAGS := \
+  -falign-functions -falign-labels -falign-loops
+
+CLANG_QCOM_CONFIG_KRAIT_MEM_FLAGS := \
+  -L $(LLVM_PREBUILTS_LIBRARIES_PATH_QCOM)/linux-propri_rt/ \
+  -l clang_rt.optlibc-krait
+
+CLANG_QCOM_CONFIG_KRAIT_PARALLEL_FLAGS :=\
+  -L $(LLVM_PREBUILTS_LIBRARIES_PATH_QCOM)/linux-propri_rt/ \
+  -l clang_rt.translib32 \
+  -fparallel
+
+ifeq ($(USE_CLANG_QCOM_LTO),true)
+  CLANG_QCOM_CONFIG_LTO_FLAGS := -flto 
+  #-c-lto
+endif
+
+ifeq ($(USE_CLANG_QCOM_VERBOSE),true)
+  CLANG_QCOM_VERBOSE := -v 
+  #-ccc-print-phases \
+  #-H
+endif
+
+# See documentation especialy 3.4.21 Math optimization.
+CLANG_QCOM_CONFIG_KRAIT_FLAGS := \
+  $(clang_qcom_mcpu) -mfpu=neon-vfpv4 -mfloat-abi=softfp -marm \
+  $(clang_qcom_muse-optlibc) \
+  -fvectorize-loops \
+  -fomit-frame-pointer \
+  -foptimize-sibling-calls \
+  -fdata-sections \
+  $(CLANG_QCOM_CONFIG_LLVM_DEFAULT_FLAGS) \
+  $(CLANG_QCOM_CONFIG_LLVM_EXTRA_FLAGS) \
+  $(CLANG_QCOM_CONFIG_KRAIT_ALIGN_FLAGS) \
+  $(CLANG_QCOM_CONFIG_KRAIT_MEM_FLAGS) \
+  -funsafe-math-optimizations \
+  -ffp-contract=fast \
+  -ffuse-loops \
+  -pipe
+
+CLANG_QCOM_CONFIG_KRAIT_LDFLAGS := \
+  $(CLANG_QCOM_CONFIG_KRAIT_FLAGS) \
+  $(CLANG_QCOM_CONFIG_KRAIT_MEM_FLAGS) \
+  -Wl,--gc-sections \
+  -Wl,--sort-common
+
+CLANG_QCOM_CONFIG_KRAIT_Ofast_FLAGS := \
+  -Ofast -fno-fast-math \
+  $(CLANG_QCOM_CONFIG_KRAIT_FLAGS)
+
+CLANG_QCOM_CONFIG_arm_UNKNOWN_CFLAGS := \
+  -fipa-pta \
+  -fsection-anchors \
+  -ftree-loop-im \
+  -ftree-loop-ivcanon \
+  -fno-canonical-system-headers \
+  -frerun-cse-after-loop \
+  -fgcse-las \
+  -fgcse-sm \
+  -fivopts \
+  -frename-registers \
+  -ftracer \
+  -funsafe-loop-optimizations \
+  -funswitch-loops \
+  -fweb \
+  -fgcse-after-reload \
+  -frename-registers \
+  -finline-functions \
+  -fno-strict-volatile-bitfields \
+  -fno-unswitch-loops \
+  -fno-if-conversion
+
+
+
+### Define global flags
+define subst-clang-qcom-incompatible-arm-flags
+  $(subst -march=armv5te,$(clang_qcom_mcpu),\
+  $(subst -march=armv5e,$(clang_qcom_mcpu),\
+  $(subst -march=armv7,$(clang_qcom_mcpu),\
+  $(subst -march=armv7-a,$(clang_qcom_mcpu),\
+  $(subst -mcpu=cortex-a15,$(clang_qcom_mcpu),\
+  $(subst -mtune=cortex-a15,$(clang_qcom_mcpu),\
+  $(subst -mcpu=cortex-a8,$(clang_qcom_mcpu),\
+  $(subst -O3,-Ofast,\
+  $(subst -O2,-Ofast,\
+  $(subst -Os,-Ofast,\
+  $(1)))))))))))
+endef
+
+define subst-clang-qcom-opt
+  $(subst -O3,-Ofast,\
+  $(subst -O2,-Ofast,\
+  $(subst -O1,-Ofast,\
+  $(subst -Os,-Ofast,\
+  $(1)))))
+endef
+
+define convert-to-clang-qcom-flags
+  $(strip \
+  $(call subst-clang-qcom-incompatible-arm-flags,\
+  $(filter-out $(CLANG_QCOM_CONFIG_arm_UNKNOWN_CFLAGS),\
+  $(1))))
+endef
+
+define convert-to-clang-qcom-ldflags
+  $(strip \
+  $(filter-out $(CLANG_QCOM_CONFIG_arm_UNKNOWN_CFLAGS),\
+  $(1)))
+endef
+
+CLANG_QCOM_CONFIG_arm_TARGET_EXTRA_CFLAGS := \
+  -nostdlibinc \
+  $(CLANG_QCOM_CONFIG_KRAIT_Ofast_FLAGS) \
+  -B$(CLANG_QCOM_CONFIG_arm_TARGET_TOOLCHAIN_PREFIX) \
+  -target $(CLANG_QCOM_CONFIG_arm_TARGET_TRIPLE) \
+  $(CLANG_QCOM_VERBOSE)
+
+CLANG_QCOM_CONFIG_arm_TARGET_EXTRA_CPPFLAGS := \
+  -nostdlibinc \
+  $(CLANG_QCOM_CONFIG_KRAIT_Ofast_FLAGS) \
+  -target $(CLANG_QCOM_CONFIG_arm_TARGET_TRIPLE) \
+  $(CLANG_QCOM_VERBOSE)
+
+CLANG_QCOM_CONFIG_arm_TARGET_EXTRA_LDFLAGS := \
+  $(CLANG_QCOM_CONFIG_LLVM_DEFAULT_FLAGS) \
+  -B$(CLANG_QCOM_CONFIG_arm_TARGET_TOOLCHAIN_PREFIX) \
+  -target $(CLANG_QCOM_CONFIG_arm_TARGET_TRIPLE) \
+  $(CLANG_QCOM_VERBOSE) \
+  $(CLANG_QCOM_CONFIG_KRAIT_LDFLAGS)
+
+ifneq ($(USE_CLANG_QCOM_PARALLEL_ONLY_ON_SELECTED_MODULES),true)  
+  CLANG_QCOM_CONFIG_arm_TARGET_EXTRA_LDFLAGS += $(CLANG_QCOM_CONFIG_KRAIT_PARALLEL_FLAGS)
+endif
+  
+CLANG_QCOM_TARGET_GLOBAL_CFLAGS := \
+  $(call convert-to-clang-qcom-flags,$(TARGET_GLOBAL_CFLAGS)) \
+  $(CLANG_QCOM_CONFIG_arm_TARGET_EXTRA_CFLAGS)
+
+CLANG_QCOM_TARGET_GLOBAL_CPPFLAGS := \
+  $(call convert-to-clang-qcom-flags,$(TARGET_GLOBAL_CPPFLAGS)) \
+  $(CLANG_QCOM_CONFIG_arm_TARGET_EXTRA_CPPFLAGS)
+
+CLANG_QCOM_TARGET_GLOBAL_LDFLAGS := \
+  $(call convert-to-clang-qcom-ldflags,$(TARGET_GLOBAL_LDFLAGS)) \
+  $(CLANG_QCOM_CONFIG_arm_TARGET_EXTRA_LDFLAGS)
+
+
+
+### Set toolchain
+CLANG_QCOM_EXTRA := \
+  -mllvm -aggressive-jt \
+  -mllvm -arm-expand-memcpy-runtime=16 \
+  -mllvm -arm-opt-memcpy=1
+
+CLANG_QCOM := $(LLVM_PREBUILTS_PATH_QCOM)/clang$(BUILD_EXECUTABLE_SUFFIX) $(CLANG_QCOM_EXTRA)
+CLANG_QCOM_CXX := $(LLVM_PREBUILTS_PATH_QCOM)/clang++$(BUILD_EXECUTABLE_SUFFIX) $(CLANG_QCOM_EXTRA)
+
+LLVM_AS := $(LLVM_PREBUILTS_PATH_QCOM)/llvm-as$(BUILD_EXECUTABLE_SUFFIX) $(CLANG_QCOM_EXTRA)
+LLVM_LINK := $(LLVM_PREBUILTS_PATH_QCOM)/llvm-link$(BUILD_EXECUTABLE_SUFFIX) $(CLANG_QCOM_EXTRA)
+
+CLANG_QCOM_CONFIG_EXTRA_TARGET_C_INCLUDES := $(LLVM_PREBUILTS_HEADER_PATH_QCOM)
+
+
+
+### Define modules
+ifeq ($(CLANG_QCOM_COMPILE_ART),true)
+  CLANG_QCOM_ART_MODULES := \
+    art \
+    libsigchain \
+    libart \
+    libart-compiler \
+    libartd \
+    libartd-compiler \
+    libart-disassembler \
+    libartd-disassembler \
+    core.art-host \
+    core.art \
+    cpplint-art-phony \
+    libnativebridgetest \
+    libarttest \
+    art-run-tests \
+    libart-gtest
+
+endif
+
+ifeq ($(CLANG_QCOM_COMPILE_BIONIC),true)
+  CLANG_QCOM_BIONIC_MODULES := \
+    libc_cxa \
+    libc_syscalls \
+    libc_aeabi \
+    libstdc++ \
+    libc_nomalloc \
+    libc_malloc \
+    libc_bionic \
+    libc \
+    libc_common \
+    libm \
+    libdl \
+    libc_gdtoa \
+    libc_stack_protector \
+    libc_tzcode \
+    libc_dns \
+    libc_freebsd \
+    libc_netbsd \
+    libc_openbsd
+    #libc_malloc_debug_qemu
+    #libc_malloc_debug_leak
+
+endif
+
+ifeq ($(CLANG_QCOM_COMPILE_MIXED),true)
+  CLANG_QCOM_EXTRA_MODULES := \
+    libskia \
+    libjpeg_static \
+    libjpeg \
+    cjpeg \
+    djpeg \
+    libft2 \
+    libsqlite3_android \
+    libsqlite \
+    sqlite3 \
+    libwebp-encode \
+    libwebp-decode \
+    libwebm \
+    libz \
+    libunz \
+    gzip \
+    libtruezip \
+    liblz4-static \
+    lz4 \
+    liblzo-static \
+    liblzo \
+    zip \
+    libbz \
+    libstlport \
+    libstlport_static \
+    libgabi++
+
+  CLANG_QCOM_EXTRA_MODULES += \
+    libion \
+    lib_core_neon_offsets \
+    libgui \
+    libui \
+    hwcStress \
+    hwcRects \
+    hwcColorEquiv \
+    hwcCommit \
+    gralloc.default \
+    hwcomposer.default \
+    audio.primary.default \
+    audio_policy.stub \
+    liboverlay \
+    math \
+    surfaceflinger
+
+  CLANG_QCOM_EXTRA_MODULES += \
+    libandroid \
+    libandroid_servers \
+    libcompiler_rt
+
+  CLANG_QCOM_EXTRA_MODULES += \
+    libpixman \
+    libmedia
+
+  CLANG_QCOM_EXTRA_MODULES += \
+    libjemalloc
+
+  CLANG_QCOM_EXTRA_MODULES_test_not_working += \
+    libcv \
+    libcvaux \
+    libcvml \
+    libcvhighgui \
+    libopencv \
+    stagefright \
+    record \
+    recordvideo \
+    screenrecord \
+    codec \
+    muxer \
+    libdownmix \
+    libeffects \
+    libvisualizer \
+    libmedia_helper \
+    libaudioparameter \
+    decoder \
+    libserviceutility \
+    libaudioresampler \
+    libaudio-resampler \
+    libaudiopolicymanagerdefault \
+    libaudiopolicymanager \
+    servicemanager \
+    halutil \
+    libhardware \
+    libqdMetaData \
+    libhdmi \
+    libqservice \
+    libOmxCore \
+    libmm-omxcore \
+    libstagefrighthw \
+    libdashplayer \
+    libutils
+
+endif
+
+# Here you can overwrite which modules should be compiled with QCOM CLANG instead of GCC
+CLANG_QCOM_FORCE_COMPILE_MODULES += \
+  $(CLANG_QCOM_ART_MODULES) \
+  $(CLANG_QCOM_BIONIC_MODULES) \
+  $(CLANG_QCOM_EXTRA_MODULES)
+
+# Here you can overwrite which modules should be compiled with the default CLANG instead of QCOM CLANG
+CLANG_QCOM_FORCE_COMPILE_ACLANG_MODULES +=
+
+# -fparallel where to use? see 3.6.4
+# Modules that dont like -fparallel
+CLANG_QCOM_DONT_USE_PARALLEL_MODULES := \
+  libc_gdtoa \
+  libm \
+  libc_tzcode \
+  libc_dns \
+  libc_freebsd \
+  libc_netbsd \
+  libc_openbsd \
+  libc_stack_protector \
+  libjemalloc
+
+# Dont use CLANG Assembler. Use GCC Assembler instead
+# https://android-review.googlesource.com/#/c/110170/
+# Skia doesnt like the CLANG assembler
+CLANG_QCOM_DONT_USE_INTEGRATED_AS_MODULES += \
+  libskia \
+  libc++abi
+
+# Modules for language mode C++11
+CLANG_QCOM_C++11_MODULES += \
+  libjni_latinime_common_static \
+  libjni_latinime
+
+# Modules for language mode G++11
+CLANG_QCOM_GNU++11_MODULES +=
+
+#CLANG_QCOM_DONT_REPLACE_WITH_Ofast_MODULES +=

--- a/core/clang/clang_qcom_global.mk
+++ b/core/clang/clang_qcom_global.mk
@@ -1,0 +1,26 @@
+# Flags and linking
+my_target_c_includes += $(CLANG_QCOM_CONFIG_EXTRA_TARGET_C_INCLUDES)
+my_target_global_cflags := $(CLANG_QCOM_TARGET_GLOBAL_CFLAGS)
+my_target_global_cppflags := $(CLANG_QCOM_TARGET_GLOBAL_CPPFLAGS)
+my_target_global_ldflags := $(CLANG_QCOM_TARGET_GLOBAL_LDFLAGS)
+
+ifneq ($(LOCAL_MODULE),$(filter $(LOCAL_MODULE),$(CLANG_QCOM_DONT_USE_PARALLEL_MODULES)))
+my_target_global_cflags += $(CLANG_QCOM_CONFIG_KRAIT_PARALLEL_FLAGS)
+my_target_global_cppflags += $(CLANG_QCOM_CONFIG_KRAIT_PARALLEL_FLAGS)
+my_target_global_ldflags += $(CLANG_QCOM_CONFIG_KRAIT_PARALLEL_FLAGS)
+endif
+
+# build for arm
+LOCAL_ARM_MODE := arm
+
+ifeq ($(CLANG_QCOM_SHOW_FLAGS),true)
+$(info global MODULE       : $(LOCAL_MODULE))
+$(info global cflags       : $(my_target_global_cflags))
+$(info global cppflags     : $(my_target_global_cppflags))
+$(info global ldflags      : $(my_target_global_ldflags))
+$(info )
+endif
+
+# Set path to CLANG binary
+my_cc := $(CLANG_QCOM)
+my_cxx := $(CLANG_QCOM_CXX)

--- a/core/clang/clang_qcom_local.mk
+++ b/core/clang/clang_qcom_local.mk
@@ -1,0 +1,54 @@
+# Convert for CLANG QCOM
+my_cflags := $(call convert-to-clang-qcom-flags,$(my_cflags))
+my_cppflags := $(call convert-to-clang-qcom-flags,$(my_cppflags))
+my_ldflags := $(call convert-to-clang-qcom-ldflags,$(my_ldflags))
+LOCAL_CONLYFLAGS := $(call convert-to-clang-qcom-flags,$(LOCAL_CONLYFLAGS))
+
+# Substitute -O2 and -O3 with -Ofast -fno-fast-math
+ifneq ($(LOCAL_MODULE),$(filter $(LOCAL_MODULE),$(CLANG_QCOM_DONT_REPLACE_WITH_Ofast_MODULES)))
+my_cflags := $(call subst-clang-qcom-opt,$(my_cflags))
+my_cppflags := $(call subst-clang-qcom-opt,$(my_cppflags))
+LOCAL_CONLYFLAGS := $(call subst-clang-qcom-opt,$(LOCAL_CONLYFLAGS))
+endif
+
+# Flags and linking
+my_cflags += $(CLANG_QCOM_CONFIG_KRAIT_Ofast_FLAGS)
+my_cppflags += $(CLANG_QCOM_CONFIG_KRAIT_Ofast_FLAGS)
+my_ldflags += $(CLANG_QCOM_CONFIG_KRAIT_LDFLAGS)
+LOCAL_CONLYFLAGS += $(CLANG_QCOM_CONFIG_KRAIT_Ofast_FLAGS)  
+# Set different mcpu for GCC Assembler because it doesnt know -mcpu=krait and defaults to -march=armv7-a
+my_asflags += $(clang_qcom_mcpu_as)
+
+ifneq ($(LOCAL_MODULE),$(filter $(LOCAL_MODULE),$(CLANG_QCOM_DONT_USE_PARALLEL_MODULES)))
+my_cflags += $(CLANG_QCOM_CONFIG_KRAIT_PARALLEL_FLAGS)
+my_cppflags += $(CLANG_QCOM_CONFIG_KRAIT_PARALLEL_FLAGS)
+my_asflags += $(CLANG_QCOM_CONFIG_KRAIT_PARALLEL_FLAGS)
+my_ldflags += $(CLANG_QCOM_CONFIG_KRAIT_PARALLEL_FLAGS)
+LOCAL_CONLYFLAGS += $(CLANG_QCOM_CONFIG_KRAIT_PARALLEL_FLAGS)
+endif
+
+# Set language dialect to C++11
+ifeq ($(LOCAL_MODULE),$(filter $(LOCAL_MODULE),$(CLANG_QCOM_C++11_MODULES)))
+my_cppflags += -std=c++11
+endif
+
+# Set language dialect to C++11
+ifeq ($(LOCAL_MODULE),$(filter $(LOCAL_MODULE),$(CLANG_QCOM_GNU++11_MODULES)))
+my_cppflags += -std=gnu++11
+endif
+
+# libc++abi bug: https://android-review.googlesource.com/#/c/110170/
+# Skia doesnt like the clang assembler
+ifeq ($(LOCAL_MODULE),$(filter $(LOCAL_MODULE),$(CLANG_QCOM_DONT_USE_INTEGRATED_AS_MODULES)))
+my_cflags += -no-integrated-as -Xassembler -mcpu=cortex-a15
+endif
+
+ifeq ($(CLANG_QCOM_SHOW_FLAGS_LOCAL),true)
+$(info local MODULE       : $(LOCAL_MODULE))
+$(info cflags             : $(my_cflags))
+$(info cppflags           : $(my_cppflags))
+$(info asflags            : $(my_asflags))
+$(info ldflags            : $(my_ldflags))    
+$(info conly              : $(LOCAL_CONLYFLAGS))
+$(info )
+endif

--- a/core/clang/clang_qcom_objects.mk
+++ b/core/clang/clang_qcom_objects.mk
@@ -1,0 +1,20 @@
+# Convert for QCOM CLANG
+arm_objects_cflags := $(call convert-to-clang-qcom-flags,$($(LOCAL_2ND_ARCH_VAR_PREFIX)$(my_prefix)$(arm_objects_mode)_CFLAGS))
+normal_objects_cflags := $(call convert-to-clang-qcom-flags,$($(LOCAL_2ND_ARCH_VAR_PREFIX)$(my_prefix)$(normal_objects_mode)_CFLAGS))
+
+ifneq ($(LOCAL_MODULE),$(filter $(LOCAL_MODULE),$(CLANG_QCOM_DONT_USE_PARALLEL_MODULES)))
+arm_objects_cflags += $(CLANG_QCOM_CONFIG_KRAIT_PARALLEL_FLAGS)
+normal_objects_cflags += $(CLANG_QCOM_CONFIG_KRAIT_PARALLEL_FLAGS)
+endif
+
+# Add KRAIT FLAGS
+arm_objects_cflags += $(CLANG_QCOM_CONFIG_KRAIT_Ofast_FLAGS) 
+normal_objects_cflags += $(CLANG_QCOM_CONFIG_KRAIT_Ofast_FLAGS)
+
+#ersetze memcpy aus libc++ mit der aus optlibc
+ifeq ($(CLANG_QCOM_SHOW_FLAGS_OBJECT),true)
+$(info object MODULE       : $(LOCAL_MODULE))
+$(info arm_objects_cflags  : $(arm_objects_cflags))
+$(info normal_objects_c    : $(normal_objects_cflags))
+$(info )
+endif

--- a/core/clang/config.mk
+++ b/core/clang/config.mk
@@ -106,3 +106,8 @@ ADDRESS_SANITIZER_CONFIG_EXTRA_STATIC_LIBRARIES := libasan
 # This allows us to use the superset of functionality that compiler-rt
 # provides to Clang (for supporting features like -ftrapv).
 COMPILER_RT_CONFIG_EXTRA_STATIC_LIBRARIES := libcompiler_rt-extras
+
+# Use Snapdragon LLVM Compiler for Android
+ifeq ($(USE_CLANG_QCOM),true)
+include $(BUILD_SYSTEM)/clang/TARGET_arm_qcom.mk
+endif


### PR DESCRIPTION
(https://developer.qualcomm.com/mobile-development/increase-app-performance/snapdragon-llvm-compiler-android)
for Android Lollipop 5.x for devices with Qualcomm CPU

As far as I know nobody has done that yet. Except me :)

This changes the toolchain for CLANG from the default one which comes
with Android (aCLANG) to the Qualcomm Snapdragon LLVM Compiler 3.6
(qCLANG) mentioned above. The toolchain will be used for almost all
places where the default Android CLANG (aCLANG) is used for compiling
TARGET MODULES. BUT ONLY if "USE_CLANG_QCOM := true" is set. Otherwise
it is using aCLANG. So you can merge this commit and the build will be
the same as before except you specifically define "USE_CLANG_QCOM :=
true"!

WARNING: THIS IS NOT FULLY TESTED FOR STABILITY YET. READ CAREFULLY It
is very likely that using this toolchain, especially with the
optimizations flags, will introduce BUGS!

I would suggest: IF YOU USE IT DONT MAKE BUG REPORTS FOR YOUR OFFICIAL
ROM OR KERNEL OR ANY APPS. Make reports in the development thread. The
ROM compiles, boots and starts. Also if Bionic and other modules are
compiled with Qualcomm Snapdragon LLVM Compiler 3.6 (qCLANG).
Androbench, Antutu, Basemark 2.0 , Geekbench 3, Vellamo are 'completing'
the benchmarks. This is a work in progress. There is confirmation that
it works for Sony Z Ultra and Samsung Galaxy Note 4 and after some
months of testing everything seems good.

At the moment this is only tested with Qualcomm Snapdragon but in theory
this should also work with any Krait and even Scorpion CPU. According to
Documentation there is also support for armv8/aarch64 (Snapdragon 810)
and you should gain a real performance bump but support is not yet
implemented! If you have a Snapdragon 810 device and want to try this
out contact me please.

Install instructions:
1. You have to make an account in order to download the toolchain!
2. You need to download the toolchain and extract it to {your android
   dir}/prebuilts/clang/linux-x86/host/*
3. Add the repo (https://github.com/mustermaxmueller/clanglibs) to your
   manifest. For example: <project path="vendor/clanglibs"
   name="mustermaxmueller/clanglibs" remote="github"
   revision="clang_qcom_3.6"/>
4. Replace the compiler-rt repo with this one
   https://github.com/mustermaxmueller/compiler-rt in your manifest For
   example: <project path="external/compiler-rt"
   name="mustermaxmueller/compiler-rt" remote="github"
   revision="clang_qcom_3.6"/>
5. Add my build repo https://github.com/mustermaxmueller/android_build/
   or merge my changes. For example: <project path="build"
   name="mustermaxmueller/android_build" remote="github"
   revision="master"/>
6. Add my frameworks_rs repo
   https://github.com/mustermaxmueller/android_frameworks_rs or merge my
   changes. For example: <project path="build"
   name="mustermaxmueller/android_build" remote="github"
   revision="master"/>
   
   You need the Qualcomm Snapdragon LLVM Compiler 3.5 for this to
   work!!!
   OR
   Make changes to
   frameworks/rs/driver/runtime/build_bc_lib_internal.mk like stated here:
   http://forum.xda-developers.com/showpost.php?p=59626153&postcount=47
7. Change following line in following files:

prebuilts/ndk/current/platforms/android-14/arch-arm/usr/include/math.h
prebuilts/ndk/current/platforms/android-8/arch-arm/usr/include/math.h
from
# if !defined(**clang**) || **clang_major** > 3 || (**clang_major** == 3

&& **clang_minor** >= 6)
to
# if !defined(**clang**) || **clang_major** > 3 || (**clang_major** == 3

&& **clang_minor** >= 7)
1. Set "USE_CLANG_QCOM := true" e.g. in Boardconfig.mk
   
   OPTIONAL (set these options in your Boardconfig.mk):
   USE_CLANG_QCOM_VERBOSE := true (give extra output when compiling)
   USE_CLANG_QCOM_LTO := true (use LTO; not working at the moment)
   CLANG_QCOM_COMPILE_ART := true (compile art with qclang; not working
   at the moment!)
   CLANG_QCOM_COMPILE_BIONIC := true (compile bionic with qclang)
   CLANG_QCOM_COMPILE_MIXED := true (compile defined modules with
   qclang)
   CLANG_QCOM_FORCE_COMPILE_MODULES += (Here you can overwrite which
   modules should be compiled with qCLANG instead of GCC)
   CLANG_QCOM_FORCE_COMPILE_ACLANG_MODULES += (Here you can overwrite
   which modules should be compiled with aCLANG instead of qCLANG)
   CLANG_QCOM_DONT_REPLACE_WITH_Ofast_MODULES += (Here you can
   overwrite which modules shouldnt be compiled with -Ofast)
2. Add "USE_CLANG_QCOM := true" to your
   Boardconfig.mk/BoardconfigCommon.mk of your device.
   (If you want to be certain that qclang is used,also set
   "USE_CLANG_QCOM_VERBOSE := true" in your Boardconfig.mk and you will see
   the verbose output while compiling.)
3. Make a clean compile! Also delete ccache!

Annotation:
1. You should only get measurable performance benefits if you compile
Bionic with CLANG!
2. Documentation for the toolchain: {your android
dir}/prebuilts/clang/linux-x86/host/llvm-Snapdragon_LLVM_for_Android_3.6/Snapdragon_LLVM_ARM_36_User_Guide.pdf
3. The Flags "-muse-optlibc" and "-ffuse-loops" are not Documented.
(http://pastebin.com/PZtk6WHB)
4. The implementation is not beautiful but it works
5. HOST is compiled with aCLANG because qCLANG does not understand x86
6. You can make performance and size comparisons by removing/commenting
"USE_CLANG_QCOM := true"
7. I could have made the installation easier by uploading the toolchain
to Github but I do not know if I am allowed to. And I am no lawyer so...

TODO:
-Make more performance comparisons to aCLANG and GCC. It seems good even
compared to GCC
-Use ccache -Where does it make sense to use qCLANG instead of GCC?
-Compile Android with qCLANG wherever possible.
http://www.linuxplumbersconf.org/2013/ocw/system/presentations/1131/original/LP2013-Android-clang.pdf
and
https://events.linuxfoundation.org/sites/events/files/slides/2014-ABS-LLVMLinux.pdf

Development Thread:
http://forum.xda-developers.com/android/software-hacking/wip-compile-android-5-0-2-qualcomm-llvm-t3035162
