### PR TITLE
build: Don't load dt.img task if custom mkbootimg is used

### DIFF
--- a/core/tasks/dt_image.mk
+++ b/core/tasks/dt_image.mk
@@ -1,6 +1,7 @@
 #----------------------------------------------------------------------
 # Generate device tree image (dt.img)
 #----------------------------------------------------------------------
+ifeq ($(strip $(BOARD_CUSTOM_BOOTIMG_MK)),)
 ifeq ($(strip $(BOARD_KERNEL_SEPARATED_DT)),true)
 ifeq ($(strip $(BUILD_TINY_ANDROID)),true)
 include device/qcom/common/dtbtool/Android.mk
@@ -31,4 +32,5 @@ $(INSTALLED_DTIMAGE_TARGET): $(DTBTOOL) $(INSTALLED_KERNEL_TARGET)
 
 ALL_DEFAULT_INSTALLED_MODULES += $(INSTALLED_DTIMAGE_TARGET)
 ALL_MODULES.$(LOCAL_MODULE).INSTALLED += $(INSTALLED_DTIMAGE_TARGET)
+endif
 endif


### PR DESCRIPTION
Change-Id: I7617554a8dc6f44ea0c6a713d834da4fe558caec
