### PR TITLE
eat: GTFO after done eating

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -754,7 +754,7 @@ function eat()
         sleep 1
         adb wait-for-device
         cat << EOF > /tmp/command
---sideload
+--sideload_auto_reboot
 EOF
         if adb push /tmp/command /cache/recovery/ ; then
             echo "Rebooting into recovery for sideload installation"


### PR DESCRIPTION
- We need to use sideload_auto_reboot if we want to eat and run.

Change-Id: I09c31bdd7a381f5fe74cd527c3019f1c3d9be2c3
